### PR TITLE
cast to int to avoid exceptions being thrown with SS 4.0.1

### DIFF
--- a/src/ImageShortcodeHandler.php
+++ b/src/ImageShortcodeHandler.php
@@ -70,7 +70,7 @@ class ImageShortcodeHandler
 
             foreach ($densities as $density) {
                 $density = (int)$density;
-                $resized = $record->ResizedImage(ceil($width * $density), ceil($height * $density));
+                $resized = $record->ResizedImage((int)ceil($width * $density), (int)ceil($height * $density));
                 // Output in the format "assets/foo.jpg 1x"
                 $srcsetSources[] = $resized->getURL() . " {$density}x";
             }


### PR DESCRIPTION
Fixes issue introduced with `silverstripe/assets`, `v1.0.1`. Also see:
https://github.com/silverstripe/silverstripe-assets/issues/103

If the other issue will be resolved, this PR probably won't need merging…